### PR TITLE
Add revival API with JustGiving test implementation

### DIFF
--- a/DonateCraftNode/.env
+++ b/DonateCraftNode/.env
@@ -1,3 +1,4 @@
 DC_DB_USERNAME=db_user
-DC_DB_PASSWORD=db_passDC_JG_API_KEY=apikey
+DC_DB_PASSWORD=db_pass
+DC_JG_API_KEY=apikey
 DC_EXTERNAL_HOST=http://localhost:8000

--- a/DonateCraftNode/.env
+++ b/DonateCraftNode/.env
@@ -1,2 +1,3 @@
 DC_DB_USERNAME=db_user
-DC_DB_PASSWORD=db_pass
+DC_DB_PASSWORD=db_passDC_JG_API_KEY=apikey
+DC_EXTERNAL_HOST=http://localhost:8000

--- a/DonateCraftNode/package-lock.json
+++ b/DonateCraftNode/package-lock.json
@@ -155,7 +155,8 @@
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -1333,14 +1334,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "prompt-sync": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/prompt-sync/-/prompt-sync-4.2.0.tgz",
-      "integrity": "sha512-BuEzzc5zptP5LsgV5MZETjDaKSWfchl5U9Luiu8SKp7iZWD5tZalOxvNcZRwv+d2phNFr8xlbxmFNcRKfJOzJw==",
-      "requires": {
-        "strip-ansi": "^5.0.0"
-      }
-    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -1642,6 +1635,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^4.1.0"
       }
@@ -1883,6 +1877,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/DonateCraftNode/package.json
+++ b/DonateCraftNode/package.json
@@ -17,7 +17,9 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "mysql": "^2.18.1",
-    "typeorm": "0.2.31"
+    "typeorm": "0.2.31",
+    "uuid": "^8.3.2",
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@types/cors": "^2.8.10",

--- a/DonateCraftNode/src/entities/RevivalLock.ts
+++ b/DonateCraftNode/src/entities/RevivalLock.ts
@@ -1,0 +1,26 @@
+import {Entity, Column, PrimaryGeneratedColumn} from 'typeorm';
+
+@Entity()
+export class RevivalLock {
+
+    @PrimaryGeneratedColumn()
+    id!: number;
+
+    @Column()
+    key!: string;
+
+    @Column()
+    reference!: string;
+
+    @Column()
+    unlockurl!: string;
+
+    @Column()
+    donationid!: number;
+
+    @Column()
+    unlocked!: boolean;
+
+    @Column()
+    value!: number;
+}

--- a/DonateCraftNode/src/index.ts
+++ b/DonateCraftNode/src/index.ts
@@ -1,20 +1,35 @@
 import express from 'express';
 import {createConnection} from 'typeorm';
 import {Death} from './entities/Death';
+import {RevivalLock} from './entities/RevivalLock';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import {DeathsDto} from "./dtos/deaths.dto";
 import path from "path";
+const { v4: uuidv4 } = require('uuid');
+const parseString = require('xml2js').parseString;
+import http from 'http';
+const util = require('util')
 require('dotenv').config()
 
 const DC_DB_USERNAME = process.env.DC_DB_USERNAME;
 const DC_DB_PASSWORD = process.env.DC_DB_PASSWORD;
+const DC_JG_API_KEY = process.env.DC_JG_API_KEY;
+const DC_EXTERNAL_HOST = process.env.DC_EXTERNAL_HOST;
 if(!DC_DB_USERNAME) {
   console.error("DC_DB_USERNAME not set");
   process.exit(-1);
 }
 if(!DC_DB_PASSWORD) {
   console.error("DC_DB_PASSWORD not set");
+  process.exit(-1);
+}
+if(!DC_JG_API_KEY) {
+  console.error("DC_JG_API_KEY not set");
+  process.exit(-1);
+}
+if(!DC_EXTERNAL_HOST) {
+  console.error("DC_EXTERNAL_HOST not set");
   process.exit(-1);
 }
 
@@ -30,6 +45,8 @@ app.listen(PORT, () => {
 app.get('/', (request, response) => {
     response.sendFile(path.resolve(__dirname, 'build', 'index.html'));
 });
+
+// Death API
 
 app.post('/death', jsonParser, (request, res) => {
     const uuid = request.body.uuid;
@@ -86,3 +103,223 @@ app.get('/deaths', jsonParser, (request, response) => {
         response.end(JSON.stringify(deathDTO));
     }).catch(error => console.log(error));
 });
+
+// Revival API
+
+app.post('/lock', jsonParser, (request, response) => {
+  const key = request.body.key;
+  const charityId = request.body.charityId || 13441;
+  const value = request.body.donationValue || 2;
+  const currency = request.body.donationCurrency || "GBP";
+  const skipGiftAid = request.body.skipGiftAid || false;
+
+  // References can only be 8 characters. This should be sufficient as each
+  // donation id is unique and is used on the callback.
+  const reference = uuidv4().substring(0, 8);
+
+  const callbackURL = encodeURIComponent(DC_EXTERNAL_HOST + "/callback?jgDonationId=JUSTGIVING-DONATION-ID");
+
+  const url = "https://link.staging.justgiving.com/v1/charity/donate/charityId/" + charityId
+  + "?donationValue=" + value
+  + "&currency=" + currency
+  + "&reference=" + reference
+  + "&skipGiftAid=" + skipGiftAid
+  + "&exiturl=" + callbackURL;
+
+  // Register key into DB
+  createConnection({
+      type: "mysql",
+      host: "localhost",
+      port: 3306,
+      username: DC_DB_USERNAME,
+      password: DC_DB_PASSWORD,
+      database: "donatecraft",
+      entities: [
+          RevivalLock
+      ],
+      synchronize: true,
+      logging: false
+  }).then(async connection => {
+      const lockRepository = connection.getRepository(RevivalLock);
+      let lock: RevivalLock | undefined = await lockRepository.findOne({key: key})
+      if (lock === undefined) {
+          lock = new RevivalLock();
+          lock.key = key;
+          lock.reference = reference;
+          lock.unlockurl = url;
+          lock.donationid = -1;
+          lock.unlocked = false;
+          lock.value = value;
+          await connection.manager.save(lock);
+          await connection.close();
+          response.send(url);
+      } else {
+          await connection.close();
+          response.status(400).send('Lock already exists')
+      }
+  }).catch(error => console.log(error));
+});
+
+app.get('/unlockURL/:key', jsonParser, (request, response) => {
+    const key = request.params.key;
+    createConnection({
+        type: "mysql",
+        host: "localhost",
+        port: 3306,
+        username: DC_DB_USERNAME,
+        password: DC_DB_PASSWORD,
+        database: "donatecraft",
+        entities: [
+            RevivalLock
+        ],
+        synchronize: true,
+        logging: false
+    }).then(async connection => {
+        const lockRepository = connection.getRepository(RevivalLock);
+        let lock: RevivalLock | undefined = await lockRepository.findOne({key: key});
+        await connection.close();
+        if (lock === undefined) {
+            response.status(404).send('Lock not found for key: ' + key);
+        } else {
+            response.send(lock.unlockurl);
+        }
+    }).catch(error => console.log(error));
+});
+
+function xmlToJson(url : string, callback : Function) {
+  const req = http.get(url, (res : http.IncomingMessage) => {
+    let xml = '';
+
+    res.on('data', function(chunk : string) {
+      xml += chunk;
+    });
+
+    res.on('error', function(e : string) {
+      callback(e, null);
+    });
+
+    res.on('timeout', function(e : string) {
+      callback(e, null);
+    });
+
+    res.on('end', function() {
+      parseString(xml, function(err : string, result : string) {
+        callback(null, result);
+      });
+    });
+  });
+}
+
+app.get('/unlocked/:key', jsonParser, (request, response) => {
+  const key = request.params.key;
+  createConnection({
+      type: "mysql",
+      host: "localhost",
+      port: 3306,
+      username: DC_DB_USERNAME,
+      password: DC_DB_PASSWORD,
+      database: "donatecraft",
+      entities: [
+          RevivalLock
+      ],
+      synchronize: true,
+      logging: false
+  }).then(async connection => {
+      const lockRepository = connection.getRepository(RevivalLock);
+      let lock: RevivalLock | undefined = await lockRepository.findOne({key: key})
+      if (lock === undefined) {
+          response.status(404).send('Lock not found for key: ' + key);
+      } else {
+          // If already unlocked quick return.
+          if (lock.unlocked) {
+            await connection.close();
+            response.send(lock.unlocked);
+            return;
+          }
+
+          // Otherwise if the donation id is set check the JG API status
+          if (lock.donationid > 0) {
+            const data = await util.promisify(xmlToJson)("http://api.staging.justgiving.com/"+DC_JG_API_KEY+"/v1/donation/" + lock.donationid);
+            console.debug(JSON.stringify(data, null, 2));
+
+            // If data is returned and we have a status
+            if (data && data.donation.status && data.donation.status.length > 0) {
+                const status = data.donation.status[0];
+                // We can also unlock now that the donation is accepted and hits the minimum value to avoid future calls.
+                if (status === "Accepted") {
+                  if (data.donation.amount[0] >= lock.value) {
+                    lock.unlocked = true;
+                    await connection.manager.save(lock);
+                    await connection.close();
+                    response.send(true);
+                  } else {
+                    console.error("User changed value at checkout to under required threshold. Deadlock.");
+                    await connection.close()
+                    response.send(false);
+                  }
+                }
+            }
+          }
+
+          // Otherwise return false; we have yet to get a callback to identify donation id.
+          await connection.close();
+          response.send(false);
+      }
+  }).catch(error => console.log(error));
+});
+
+app.get('/callback', jsonParser, (request, response) => {
+  const donationid = request.query.jgDonationId as string;
+  if (!donationid) {
+    response.status(404).send("No donation id found");
+    return;
+  }
+
+  createConnection({
+      type: "mysql",
+      host: "localhost",
+      port: 3306,
+      username: DC_DB_USERNAME,
+      password: DC_DB_PASSWORD,
+      database: "donatecraft",
+      entities: [
+          RevivalLock
+      ],
+      synchronize: true,
+      logging: false
+  }).then(async connection => {
+
+    const data = await util.promisify(xmlToJson)("http://api.staging.justgiving.com/"+DC_JG_API_KEY+"/v1/donation/" + donationid);
+    console.debug(JSON.stringify(data, null, 2));
+
+    // If data is returned and we have a status
+    if (data && data.donation && data.donation.status && data.donation.status.length > 0) {
+        const reference = data.donation.thirdPartyReference;
+        const lockRepository = connection.getRepository(RevivalLock);
+        let lock: RevivalLock | undefined = await lockRepository.findOne({reference: reference})
+        if (lock === undefined) {
+          // We have a donation that we can't reference.
+          await connection.close();
+          response.status(404).send("Cannot find associated lock for donation: " + donationid + " ref: " + reference);
+          return;
+        } else {
+          lock.donationid = parseInt(donationid);
+        }
+
+        const status = data.donation.status[0];
+        // We can also unlock now that the donation is accepted and hits the minimum value to avoid future calls.
+        if (status === "Accepted") {
+          if (data.donation.amount[0] >= lock.value) {
+            lock.unlocked = true;
+          } else {
+            console.error("User changed value at checkout to under required threshold. Deadlock.");
+          }
+        }
+
+        await connection.manager.save(lock);
+        await connection.close();
+        response.send("Donation callback received successfully. Thank you!");
+    }
+  }).catch(error => console.log(error));
+});
+


### PR DESCRIPTION
This adds the following APIs:
* POST /lock - Takes a JSON object with a key (as well as donation
  specific criteria) returning a URL for a user to unlock.
* GET /unlockURL/<key> - Returns a URL if lost when posting.
* GET /unlocked/<key> - Returns true if key is unlocked false otherwise.
* GET /callback/?jgDonationId=. - Upon completion of a donation users
  are redirected to this page. This triggers this flow allowing us to
  associate the donation id (required for lookups) with the key
  reference.