### PR TITLE
Drop player head on death

### DIFF
--- a/DonateCraft/src/main/java/com/vypersw/listeners/PlayerListener.java
+++ b/DonateCraft/src/main/java/com/vypersw/listeners/PlayerListener.java
@@ -4,11 +4,16 @@ import com.vypersw.MessageHelper;
 import com.vypersw.network.HttpHelper;
 import com.vypersw.response.Death;
 import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.Collections;
 
 public class PlayerListener implements Listener {
 
@@ -28,6 +33,8 @@ public class PlayerListener implements Listener {
         death.setName(player.getName());
         death.setLastDeathReason(event.getDeathMessage());
         httpHelper.fireAsyncPostRequestToServer("/lock", death, () -> messageHelper.sendDeathURL(player));
+
+        dropSkull(player, event.getDeathMessage());
     }
 
     @EventHandler
@@ -36,5 +43,14 @@ public class PlayerListener implements Listener {
         if (player.getGameMode() == GameMode.SPECTATOR) {
             messageHelper.sendDeathURL(player);
         }
+    }
+
+    private void dropSkull(Player player, String reason) {
+        ItemStack skull = new ItemStack(Material.PLAYER_HEAD, 1);
+        SkullMeta skullMeta = (SkullMeta) skull.getItemMeta();
+        skullMeta.setOwningPlayer(player);
+        skullMeta.setLore(Collections.singletonList(reason));
+        skull.setItemMeta(skullMeta);
+        player.getWorld().dropItem(player.getLocation(), skull);
     }
 }

--- a/DonateCraft/src/test/java/com/vypersw/listeners/PlayerListenerTest.java
+++ b/DonateCraft/src/test/java/com/vypersw/listeners/PlayerListenerTest.java
@@ -3,11 +3,19 @@ package com.vypersw.listeners;
 import com.vypersw.MessageHelper;
 import com.vypersw.network.HttpHelper;
 import com.vypersw.response.Death;
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Server;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.inventory.ItemFactory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,10 +26,12 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.longThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -33,6 +43,7 @@ public class PlayerListenerTest {
   private static final String DEATH_MESSAGE = "pricked to death";
   private static final String PLAYER_NAME = "Thornyfy";
   private static final UUID PLAYER_UUID = UUID.randomUUID();
+  private static final Location PLAYER_LOCATION = new Location(null, 0.1, 0.2, 0.3);
 
   @Mock
   private Player player;
@@ -43,11 +54,29 @@ public class PlayerListenerTest {
   @Mock
   private MessageHelper messageHelper;
 
+  @Mock
+  private Server server;
+
+  @Mock
+  private Logger serverLogger;
+
+  @Mock
+  private ItemFactory serverItemFactory;
+
+  @Mock
+  private SkullMeta skullMeta;
+
+  @Mock
+  private World world;
+
   @Captor
   ArgumentCaptor<Death> deathArgumentCaptor;
 
   @Captor
   ArgumentCaptor<Runnable> runnableArgumentCaptor;
+
+  @Captor
+  ArgumentCaptor<ItemStack> itemStackArgumentCaptor;
 
   private PlayerListener playerListener;
 
@@ -55,7 +84,19 @@ public class PlayerListenerTest {
   public void before() {
     when(player.getUniqueId()).thenReturn(PLAYER_UUID);
     when(player.getName()).thenReturn(PLAYER_NAME);
+    when(player.getWorld()).thenReturn(world);
+    when(player.getLocation()).thenReturn(PLAYER_LOCATION);
     playerListener = new PlayerListener(messageHelper, httpHelper);
+
+    when(server.getLogger()).thenReturn(serverLogger);
+    when(server.getItemFactory()).thenReturn(serverItemFactory);
+    when(serverItemFactory.getItemMeta(Material.PLAYER_HEAD)).thenReturn(skullMeta);
+
+    // Right now this works as it is the only test that requires Bukkit internals.
+    // If future tests require this we will need a more robust solution.
+    if (Bukkit.getServer() == null) {
+      Bukkit.setServer(server);
+    }
   }
 
 
@@ -75,6 +116,22 @@ public class PlayerListenerTest {
 
     verify(messageHelper).sendDeathURL(player);
     verifyNoMoreInteractions(messageHelper);
+
+    verify(player).getUniqueId();
+    verify(player).getName();
+    verify(player).getWorld();
+    verify(player).getLocation();
+    verifyNoMoreInteractions(player);
+
+    verify(world).dropItem(eq(PLAYER_LOCATION), itemStackArgumentCaptor.capture());
+    verifyNoMoreInteractions(world);
+
+    ItemStack skull = itemStackArgumentCaptor.getValue();
+    assertThat(skull.getAmount(), equalTo(1));
+    assertThat(skull.getType(), equalTo(Material.PLAYER_HEAD));
+    assertThat(skull.getItemMeta(), equalTo(skullMeta));
+    verify(skullMeta).setLore(Collections.singletonList(DEATH_MESSAGE));
+    verify(skullMeta).setOwningPlayer(player);
   }
 
   @Test


### PR DESCRIPTION
Closes #27
Player head has the owner of the deceased
and reason for death. The lore is only
maintained if the skull is kept as an item
(if converted to a block via placing lore
is lost).