### PR TITLE
Donation decimals rounded to 2 decimal places

### DIFF
--- a/DonateCraftNG/src/app/deaths/deaths.component.ts
+++ b/DonateCraftNG/src/app/deaths/deaths.component.ts
@@ -50,12 +50,12 @@ export class DeathsComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
 
-  getTotalDonationsForPlayer(donations: Donation[]): number {
+  getTotalDonationsForPlayer(donations: Donation[]): string {
     let total = 0;
     for (const donation of donations) {
       total += donation.amount;
     }
-    return total;
+    return total.toFixed(2);
   }
 
   getMostRecentDeathForUser(deaths: Death[]): string {


### PR DESCRIPTION
Fixing bug with donations having lots of decimals, now limited to two decimal places.