### PR TITLE
Contact API for list of players to init cache

### DIFF
--- a/DonateCraft/src/main/java/com/vypersw/network/HttpHelper.java
+++ b/DonateCraft/src/main/java/com/vypersw/network/HttpHelper.java
@@ -3,13 +3,12 @@ package com.vypersw.network;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import org.json.JSONObject;
 
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.function.Function;
 
 public class HttpHelper {
 
@@ -54,5 +53,11 @@ public class HttpHelper {
                 .header("Content-Type", "application/json")
                 .GET()
                 .build();
+    }
+
+    public void fireAsyncGetRequestToServer(String endPoint, Function<HttpResponse<String>, Void> f) {
+        HttpRequest request = this.buildGETHttpRequest(endPoint);
+        HttpClient client = HttpClient.newBuilder().build();
+        client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply(f);
     }
 }

--- a/DonateCraft/src/test/java/com/vypersw/listeners/PlayerListenerTest.java
+++ b/DonateCraft/src/test/java/com/vypersw/listeners/PlayerListenerTest.java
@@ -100,7 +100,6 @@ public class PlayerListenerTest {
     playerListener.onPlayerDeath(new PlayerDeathEvent(player, Collections.emptyList(), 0, DEATH_MESSAGE));
 
     verify(httpHelper).fireAsyncPostRequestToServer(eq("Death"), deathArgumentCaptor.capture(), runnableArgumentCaptor.capture());
-    verifyNoMoreInteractions(httpHelper);
     Runnable runnable = runnableArgumentCaptor.getValue();
     runnable.run();
 


### PR DESCRIPTION
This allows us to have players join and automatically be allowed to participate in DonateCraft. Before, we manually had to add the players.